### PR TITLE
Fix set_transaction_downloaded parameter

### DIFF
--- a/app/dhpo_client.py
+++ b/app/dhpo_client.py
@@ -133,12 +133,12 @@ class EClaimLinkClient:
             error_message=r.errorMessage
         )
 
-    def set_transaction_downloaded(self, field_id: str) -> SetTransactionDownloadedResponseModel:
-        """Mark a transaction as downloaded by field ID."""
+    def set_transaction_downloaded(self, file_id: str) -> SetTransactionDownloadedResponseModel:
+        """Mark a transaction as downloaded by file ID."""
         r = self.service.SetTransactionDownloaded(
             login=self.login,
             pwd=self.password,
-            fieldId=field_id
+            fileId=file_id
         )
         return SetTransactionDownloadedResponseModel(
             result=r.SetTransactionDownloadedResult,


### PR DESCRIPTION
## Summary
- fix parameter name typo in `EClaimLinkClient.set_transaction_downloaded`

## Testing
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_6856e74f692c8330a9b3a33cd0ba366f